### PR TITLE
Substitutes EP_TOG for EP_ON

### DIFF
--- a/config/lily58.conf
+++ b/config/lily58.conf
@@ -1,0 +1,31 @@
+##############################
+#### ---- LEFT SIDE ---- #####
+##############################
+CONFIG_ZMK_KEYBOARD_NAME="barrett58promak"
+CONFIG_ZMK_WPM=y # Enable calculating words per minute
+
+# Display settings
+CONFIG_ZMK_DISPLAY=y
+CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN=y
+CONFIG_ZMK_DISPLAY_WORK_QUEUE_SYSTEM=y
+CONFIG_ZMK_WIDGET_BATTERY_STATUS=y
+CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE=y
+CONFIG_ZMK_WIDGET_WPM_STATUS=y
+#CONFIG_SSD1306=y
+
+# Power settings
+CONFIG_ZMK_IDLE_TIMEOUT=30000
+CONFIG_ZMK_SLEEP=n # Display doesn't turn on after sleep
+#CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=900000
+
+# USB settings
+CONFIG_ZMK_USB=y
+
+# Bluetooth settings
+CONFIG_BT=y
+CONFIG_ZMK_BLE=y
+
+# Split keyboard settings
+CONFIG_ZMK_SPLIT=y
+CONFIG_ZMK_SPLIT_BLE=y
+CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_PRIORITY=4

--- a/config/lily58.conf
+++ b/config/lily58.conf
@@ -2,7 +2,7 @@
 #### ---- LEFT SIDE ---- #####
 ##############################
 CONFIG_ZMK_KEYBOARD_NAME="barrett58promak"
-CONFIG_ZMK_WPM=y # Enable calculating words per minute
+#CONFIG_ZMK_WPM=y # Enable calculating words per minute
 
 # Display settings
 CONFIG_ZMK_DISPLAY=y
@@ -11,7 +11,6 @@ CONFIG_ZMK_DISPLAY_WORK_QUEUE_SYSTEM=y
 CONFIG_ZMK_WIDGET_BATTERY_STATUS=y
 CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE=y
 CONFIG_ZMK_WIDGET_WPM_STATUS=y
-#CONFIG_SSD1306=y
 
 # Power settings
 CONFIG_ZMK_IDLE_TIMEOUT=30000

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -44,13 +44,13 @@
 
 		lower_layer {
 // ------------------------------------------------------------------------------------------------------------
-// | EP_TOG | BT1 | BT2 |  BT3 |  BT4 |  BT5 |                   |      |       |       |      |       | BTCLR |
+// | EP_ON  | BT1 | BT2 |  BT3 |  BT4 |  BT5 |                   |      |       |       |      |       | BTCLR |
 // |        |     |     |      |      |      |                   |      |       | PG_UP |      |       |       |
 // |        |     |     |      |      |      |                   |      | HOME  | PG_DN |  END |       |       |
 // |        |     |     |      |      |      |        |  |       |      |       |       |      |       |       |
 //                      |      |      |      |        |  |       |      |       |       |
 			bindings = <
-&ext_power EP_TOG  &bt BT_SEL 0  &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                 &trans  &trans  &trans  &trans &trans &bt BT_CLR
+&ext_power EP_ON  &bt BT_SEL 0  &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                 &trans  &trans  &trans  &trans &trans &bt BT_CLR
 &trans    &trans  &trans  &trans  &trans  &trans                     &trans  &trans    &kp PG_UP  &trans   &trans  &trans
 &trans    &trans  &trans  &trans  &trans  &trans                     &trans  &kp HOME  &kp PG_DN  &kp END  &trans  &trans
 &trans    &trans  &trans  &trans  &trans  &trans   &trans   &trans   &trans  &trans    &trans    &trans    &trans  &trans
@@ -62,13 +62,13 @@
 
 		raise_layer {
 // ------------------------------------------------------------------------------------------------------------
-// |       |  F1 |  F2 |  F3  |  F4  |  F5  |                   |  F6  |   F7  |   F8  |  F9  |  F10  |       |
+// |       |  F1 |  F2 |  F3  |  F4  |  F5  |                   |  F6  |   F7  |   F8  |  F9  |  F10  | EP_ON |
 // |       |     |     |      |      |      |                   |      |       |   ^   |  F11 |  F12  |   =   |
 // |   DEL |     |     |      |      |      |                   | HOME |   <-  |   v   |  ->  |  END  |       |
 // |       |     |     |      |      |      |        |  |       |      |       |       |      |   \   |       |
 //                     |      |      |      |        |  |       |      |       |       |
 			bindings = <
-&trans    &kp F1  &kp F2  &kp F3  &kp F4  &kp F5                     &kp F6    &kp F7    &kp F8    &kp F9    &kp F10   &trans
+&trans    &kp F1  &kp F2  &kp F3  &kp F4  &kp F5                     &kp F6    &kp F7    &kp F8    &kp F9    &kp F10   &ext_power EP_ON
 &trans    &trans  &trans  &trans  &trans  &trans                     &trans    &trans    &kp UP    &kp F11   &kp F12   &kp EQUAL
 &kp DEL   &trans  &trans  &trans  &trans  &trans                     &kp HOME  &kp LEFT  &kp DOWN  &kp RIGHT &kp END   &trans
 &trans    &trans  &trans  &trans  &trans  &trans   &trans   &trans   &trans    &trans    &trans    &trans    &kp BSLH  &trans

--- a/config/lily58_left.conf
+++ b/config/lily58_left.conf
@@ -19,7 +19,7 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 CONFIG_ZMK_SLEEP=n # Display doesn't turn on after sleep
 #CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=900000
 
-# USB s
+# USB settings
 CONFIG_ZMK_USB=y
 
 # Bluetooth settings

--- a/config/lily58_right.conf
+++ b/config/lily58_right.conf
@@ -17,7 +17,7 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 CONFIG_ZMK_SLEEP=n # Display doesn't turn on after sleep
 #CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=900000
 
-# USB s
+# USB settings
 CONFIG_ZMK_USB=y
 
 # Bluetooth settings


### PR DESCRIPTION
Attempting to fix the right side display not turning on. Tried resetting to factory multiple times and using a shared configuration. What seemed to work was flashing reset file to both sides, then starting with the **RIGHT** side, flashing the desired config.